### PR TITLE
Bump CI python version to 3.11 to produce working binary

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -13,8 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true


### PR DESCRIPTION
Bump CI python version to 3.11; this fixes errors from anyio regarding exceptiongroup.

It also for some reason seems to work around https://github.com/encode/httpcore/issues/663 - before I bumped the python version I was explicitly importing anyio in `__main__.py` to avoid the race condition mentioned in https://github.com/encode/httpcore/pull/692, but this doesn't *seem* to be required after the python version bump - perhaps it has pulled in newer version of httpcore?

(This also explicitly sets the step ID for the python set-up, so we can key the cache properly based on the python version.)

Fixes: #202 